### PR TITLE
Migrate Docker infrastructure from Docker Hub to AWS ECR with OIDC authentication

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
+# Shell scripts must have LF endings
 *.sh text eol=lf
+
+# Windows batch files must have CRLF endings
+*.bat text eol=crlf
+
+# Makefile should have LF endings (Make requires LF)
+Makefile text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
-name : CI Pipeline
+name: CI Pipeline
 
-on: 
+on:
   pull_request:
-    branches: [dev, main]
-
+    branches: [ci_cd]
 
 jobs:
   test:
@@ -19,21 +18,34 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
-            path: /tmp/.buildx-cache
-            key: ${{runner.os}}-buildx-${{github.sha}}
-            restore-keys: |
-              ${{runner.os}}-buildx-
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
-      - name: Create .env file from secrets
+      - name: Install AWS CLI
         run: |
-          cat > .env << EOF
-          OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-          COGNITO_REGION=${{ secrets.COGNITO_REGION }}
-          COGNITO_USER_POOL_ID=${{ secrets.COGNITO_USER_POOL_ID }}
-          COGNITO_APP_CLIENT_ID=${{ secrets.COGNITO_APP_CLIENT_ID }}
-          COGNITO_APP_CLIENT_SECRET=${{ secrets.COGNITO_APP_CLIENT_SECRET }}
+          apt-get update -y
+          apt-get install -y awscli
+
+      - name: Login to Amazon ECR
+        run: |
+          region="${AWS_REGION:-${{ secrets.AWS_REGION }}}"
+          account="${AWS_ACCOUNT_ID:-${{ secrets.AWS_ACCOUNT_ID }}}"
+          echo "Logging in to ECR in region=$region account=$account"
+          aws ecr get-login-password --region "$region" | \
+            docker login --username AWS --password-stdin \
+            "$account".dkr.ecr."$region".amazonaws.com
+
+      - name: Create .env file
+        run: |
+          cat > .env <<EOF
+          OPENAI_API_KEY=${OPENAI_API_KEY:-${{ secrets.OPENAI_API_KEY }}}
+          COGNITO_REGION=${COGNITO_REGION:-${{ secrets.COGNITO_REGION }}}
+          COGNITO_USER_POOL_ID=${COGNITO_USER_POOL_ID:-${{ secrets.COGNITO_USER_POOL_ID }}}
+          COGNITO_APP_CLIENT_ID=${COGNITO_APP_CLIENT_ID:-${{ secrets.COGNITO_APP_CLIENT_ID }}}
+          COGNITO_APP_CLIENT_SECRET=${COGNITO_APP_CLIENT_SECRET:-${{ secrets.COGNITO_APP_CLIENT_SECRET }}}
           EOF
 
-      - name: Build test container and run tests
-        run : make test
-              
+      - name: Build and test
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI Pipeline
 
 on:
   pull_request:
-    branches: [ci_cd]
+    branches: [dev]
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   test:
@@ -23,19 +27,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Install AWS CLI
-        run: |
-          apt-get update -y
-          apt-get install -y awscli
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{secrets.PULL_REQUEST_AWS_ROLE_TO_ASSUME}}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set ECR variables to pull the base image
         run: |
-          region="${AWS_REGION:-${{ secrets.AWS_REGION }}}"
-          account="${AWS_ACCOUNT_ID:-${{ secrets.AWS_ACCOUNT_ID }}}"
-          echo "Logging in to ECR in region=$region account=$account"
-          aws ecr get-login-password --region "$region" | \
-            docker login --username AWS --password-stdin \
-            "$account".dkr.ecr."$region".amazonaws.com
+          echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID }}" >> $GITHUB_ENV
+          echo "AWS_REGION=${{ secrets.AWS_REGION }}" >> $GITHUB_ENV
+          echo "ECR_REPOSITORY=chatbot" >> $GITHUB_ENV
+          echo "IMAGE_TAG=latest" >> $GITHUB_ENV
 
       - name: Create .env file
         run: |

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,24 @@
 
 .PHONY: help build build-base push-base dev test ci clean format lint lint-check fix
 
-# Detect OS and set script extension
+# Cross-platform configuration
+# Make always uses forward slashes for paths, even on Windows
+SCRIPTS := infra/docker/scripts
+
+# Detect Windows and configure appropriately
 ifeq ($(OS),Windows_NT)
     SCRIPT_EXT := .bat
-    SCRIPTS := infra\docker\scripts
+    # Use cmd.exe for .bat files and convert forward slashes to backslashes
+    SHELL := cmd.exe
+    .SHELLFLAGS := /c
+    # Convert forward slashes to backslashes for Windows
+    SCRIPTS_WIN := $(subst /,\,$(SCRIPTS))
+    RUN_SCRIPT = $(SCRIPTS_WIN)\$(1)$(SCRIPT_EXT)
 else
     SCRIPT_EXT := .sh
-    SCRIPTS := ./infra/docker/scripts
+    SHELL := /bin/bash
+    .SHELLFLAGS := -c
+    RUN_SCRIPT = ./$(SCRIPTS)/$(1)$(SCRIPT_EXT)
 endif
 
 # Default target
@@ -31,24 +42,24 @@ help: ## Show this help message
 
 # Build commands
 build: ## Build the backend application
-	$(SCRIPTS)/build$(SCRIPT_EXT)
+	$(call RUN_SCRIPT,build)
 
-build-base: ## Build base image with all dependencies
-	$(SCRIPTS)/build-base$(SCRIPT_EXT)
+build-base: ## Build base image with all dependencies (run this when pyproject.toml or uv.lock changes)
+	$(call RUN_SCRIPT,build-base)
 
 push-base: ## Build and push base image to Docker Hub
-	$(SCRIPTS)/build-base$(SCRIPT_EXT) --push
+	$(call RUN_SCRIPT,build-base) --push
 
 # Development
 dev: ## Run development environment (API + DB)
-	$(SCRIPTS)/dev$(SCRIPT_EXT)
+	$(call RUN_SCRIPT,dev)
 
 # Testing
 test: ## Run tests in CI environment
-	@bash $(SCRIPTS)/test.sh
+	$(call RUN_SCRIPT,test)
 
 ci: ## Run full CI pipeline (lint + format check + tests)
-	@bash $(SCRIPTS)/ci.sh
+	$(call RUN_SCRIPT,ci)
 
 # Cleanup
 clean: ## Clean up Docker resources

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -1,9 +1,10 @@
 # Lightweight Dockerfile for A Simple Chatbot Backend
 # Uses pre-built base image with all dependencies
 
-# Use custom base image with all dependencies pre-installed
-# Build base: docker build -f infra/docker/Dockerfile.base -t hero7hero/simple-chatbot:latest .
-ARG BASE_IMAGE=hero7hero/simple-chatbot:latest
+# Use custom base image with all dependencies pre-installed from ECR
+# Build base: make build-base
+# Push to ECR: make push-base
+ARG BASE_IMAGE
 FROM ${BASE_IMAGE} AS base
 
 # Stage for development

--- a/infra/docker/docker-compose.ci.yml
+++ b/infra/docker/docker-compose.ci.yml
@@ -11,7 +11,7 @@ services:
       dockerfile: infra/docker/Dockerfile
       target: development
       args:
-        BASE_IMAGE: hero7hero/simple-chatbot:latest
+        BASE_IMAGE: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG:-latest}
     container_name: chatbot-api-ci
     env_file:
       # Load from .env file (locally: your .env, CI: generated from secrets)

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -12,7 +12,7 @@ services:
       dockerfile: infra/docker/Dockerfile
       target: production
       args:
-        BASE_IMAGE: hero7hero/simple-chatbot:latest
+        BASE_IMAGE: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG:-latest}
     container_name: chatbot-api-prod
     environment:
       # In ECS, these come from environment variables/secrets

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -1,9 +1,3 @@
-# Production Docker Compose - For reference only
-# In production, only the backend image is deployed to ECS with ALB in front
-# Database and other services are managed externally
-
-version: '3.8'
-
 services:
   # FastAPI Application - Production (ECS deployment reference)
   api:
@@ -14,10 +8,6 @@ services:
       args:
         BASE_IMAGE: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG:-latest}
     container_name: chatbot-api-prod
-    environment:
-      # In ECS, these come from environment variables/secrets
-      - ENVIRONMENT=production
-      - DATABASE_URL=${DATABASE_URL}  # External RDS database
     ports:
       - "8000:8000"
     restart: always

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: infra/docker/Dockerfile
       target: development
       args:
-        BASE_IMAGE: hero7hero/simple-chatbot:latest
+        BASE_IMAGE: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG:-latest}
     container_name: chatbot-api-dev
     environment:
       - DATABASE_URL=postgresql://dev_user:dev_password@db:5432/chatbot_db
@@ -22,9 +22,9 @@ services:
       # Mount source code and config files for development, testing, and linting
       - ../../app:/app/app:ro
       - ../../tests:/app/tests:ro
-      - ../../pyproject.toml:/app/pyproject.toml:ro
-      - ../../uv.lock:/app/uv.lock:ro
       - ../../.flake8:/app/.flake8:ro
+      # NOTE: pyproject.toml and uv.lock are NOT mounted - they're baked into the base image
+      # If you update dependencies, rebuild the base image with: make build-base
     depends_on:
       db:
         condition: service_healthy

--- a/infra/docker/scripts/build-base.bat
+++ b/infra/docker/scripts/build-base.bat
@@ -1,10 +1,42 @@
 @echo off
-REM Build and optionally push the base image with all dependencies
+REM Build and optionally push the base image with all dependencies to AWS ECR
 
 setlocal enabledelayedexpansion
 
-set IMAGE_NAME=hero7hero/simple-chatbot
-set TAG=latest
+REM Load environment variables from .env file
+if exist .env (
+    for /f "usebackq tokens=1,2 delims==" %%a in (".env") do (
+        set "line=%%a"
+        if not "!line:~0,1!"=="#" (
+            if not "%%a"=="" (
+                set "%%a=%%b"
+            )
+        )
+    )
+)
+
+REM Check required environment variables
+if "%AWS_ACCOUNT_ID%"=="" (
+    echo [ERROR] Missing AWS_ACCOUNT_ID in .env file
+    exit /b 1
+)
+if "%AWS_REGION%"=="" (
+    echo [ERROR] Missing AWS_REGION in .env file
+    exit /b 1
+)
+if "%ECR_REPOSITORY%"=="" (
+    echo [ERROR] Missing ECR_REPOSITORY in .env file
+    exit /b 1
+)
+
+REM Construct ECR image name
+set ECR_REGISTRY=%AWS_ACCOUNT_ID%.dkr.ecr.%AWS_REGION%.amazonaws.com
+set IMAGE_NAME=%ECR_REGISTRY%/%ECR_REPOSITORY%
+if "%IMAGE_TAG%"=="" (
+    set TAG=latest
+) else (
+    set TAG=%IMAGE_TAG%
+)
 
 REM Parse arguments
 if "%1"=="--push" (
@@ -28,9 +60,17 @@ if errorlevel 1 (
 
 echo [INFO] Base image built successfully: %IMAGE_NAME%:%TAG%
 
-REM Push to registry if requested
+REM Push to ECR if requested
 if "%PUSH%"=="true" (
-    echo [INFO] Pushing to registry...
+    echo [INFO] Logging into ECR...
+    aws ecr get-login-password --region %AWS_REGION% | docker login --username AWS --password-stdin %ECR_REGISTRY%
+
+    if errorlevel 1 (
+        echo [ERROR] Failed to authenticate with ECR
+        exit /b 1
+    )
+
+    echo [INFO] Pushing to ECR...
     docker push %IMAGE_NAME%:%TAG%
 
     if errorlevel 1 (
@@ -38,8 +78,8 @@ if "%PUSH%"=="true" (
         exit /b 1
     )
 
-    echo [INFO] Base image pushed: %IMAGE_NAME%:%TAG%
+    echo [INFO] Base image pushed to ECR: %IMAGE_NAME%:%TAG%
 ) else (
-    echo [INFO] To push to Docker Hub, run: %0 --push
-    echo [INFO] Make sure you're logged in: docker login
+    echo [INFO] To push to ECR, run: %0 --push
+    echo [INFO] Make sure AWS CLI is configured with proper credentials
 )

--- a/infra/docker/scripts/build-base.sh
+++ b/infra/docker/scripts/build-base.sh
@@ -1,10 +1,24 @@
 #!/bin/bash
-# Build and optionally push the base image with all dependencies
+# Build and optionally push the base image with all dependencies to AWS ECR
 
 set -e
 
-IMAGE_NAME="hero7hero/simple-chatbot"
-TAG="latest"
+# Load environment variables from .env file
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | grep -v '^$' | xargs)
+fi
+
+# Check required environment variables
+if [ -z "$AWS_ACCOUNT_ID" ] || [ -z "$AWS_REGION" ] || [ -z "$ECR_REPOSITORY" ]; then
+    echo "[ERROR] Missing required environment variables in .env file:"
+    echo "  AWS_ACCOUNT_ID, AWS_REGION, ECR_REPOSITORY"
+    exit 1
+fi
+
+# Construct ECR image name
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+IMAGE_NAME="${ECR_REGISTRY}/${ECR_REPOSITORY}"
+TAG="${IMAGE_TAG:-latest}"
 PUSH=false
 
 # Parse arguments
@@ -32,13 +46,21 @@ docker build -f infra/docker/Dockerfile.base -t "$IMAGE_NAME:$TAG" .
 
 echo "[INFO] Base image built successfully: $IMAGE_NAME:$TAG"
 
-# Push to registry if requested
+# Push to ECR if requested
 if [[ "$PUSH" == true ]]; then
-    echo "[INFO] Pushing to registry..."
+    echo "[INFO] Logging into ECR..."
+    aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+    if [ $? -ne 0 ]; then
+        echo "[ERROR] Failed to authenticate with ECR"
+        exit 1
+    fi
+
+    echo "[INFO] Pushing to ECR..."
     docker push "$IMAGE_NAME:$TAG"
 
-    echo "[INFO] Base image pushed: $IMAGE_NAME:$TAG"
+    echo "[INFO] Base image pushed to ECR: $IMAGE_NAME:$TAG"
 else
-    echo "[INFO] To push to Docker Hub, run: $0 --push"
-    echo "[INFO] Make sure you're logged in: docker login"
+    echo "[INFO] To push to ECR, run: $0 --push"
+    echo "[INFO] Make sure AWS CLI is configured with proper credentials"
 fi

--- a/infra/docker/scripts/build.bat
+++ b/infra/docker/scripts/build.bat
@@ -1,5 +1,39 @@
 @echo off
 REM Build the backend application Docker image
 
-cd /d "%~dp0\.."
+setlocal enabledelayedexpansion
+
+REM Go to project root to load .env
+cd /d "%~dp0\..\..\..\"
+
+REM Load environment variables from .env file
+if exist .env (
+    for /f "usebackq tokens=1,2 delims==" %%a in (".env") do (
+        set "line=%%a"
+        if not "!line:~0,1!"=="#" (
+            if not "%%a"=="" (
+                set "%%a=%%b"
+            )
+        )
+    )
+)
+
+REM Check required environment variables
+if "%AWS_ACCOUNT_ID%"=="" (
+    echo [ERROR] Missing AWS_ACCOUNT_ID in .env file
+    exit /b 1
+)
+if "%AWS_REGION%"=="" (
+    echo [ERROR] Missing AWS_REGION in .env file
+    exit /b 1
+)
+if "%ECR_REPOSITORY%"=="" (
+    echo [ERROR] Missing ECR_REPOSITORY in .env file
+    exit /b 1
+)
+
+echo [INFO] Building with ECR base image: %AWS_ACCOUNT_ID%.dkr.ecr.%AWS_REGION%.amazonaws.com/%ECR_REPOSITORY%:%IMAGE_TAG%
+
+REM Build with environment variables
+cd infra\docker
 docker-compose -f docker-compose.yml build api

--- a/infra/docker/scripts/build.sh
+++ b/infra/docker/scripts/build.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 # Build the backend application Docker image
 
-cd "$(dirname "$0")/.."
+set -e
+
+# Go to project root to load .env
+cd "$(dirname "$0")/../../.."
+
+# Load environment variables from .env file
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | grep -v '^$' | xargs)
+fi
+
+# Check required environment variables
+if [ -z "$AWS_ACCOUNT_ID" ] || [ -z "$AWS_REGION" ] || [ -z "$ECR_REPOSITORY" ]; then
+    echo "[ERROR] Missing required environment variables in .env file:"
+    echo "  AWS_ACCOUNT_ID, AWS_REGION, ECR_REPOSITORY"
+    exit 1
+fi
+
+echo "[INFO] Building with ECR base image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG:-latest}"
+
+# Build with environment variables
+cd infra/docker
 docker compose -f docker-compose.yml build api

--- a/infra/docker/scripts/dev.bat
+++ b/infra/docker/scripts/dev.bat
@@ -1,5 +1,39 @@
 @echo off
 REM Run all containers for development (API + DB)
 
-cd /d "%~dp0\.."
+setlocal enabledelayedexpansion
+
+REM Go to project root to load .env
+cd /d "%~dp0\..\..\..\"
+
+REM Load environment variables from .env file
+if exist .env (
+    for /f "usebackq tokens=1,2 delims==" %%a in (".env") do (
+        set "line=%%a"
+        if not "!line:~0,1!"=="#" (
+            if not "%%a"=="" (
+                set "%%a=%%b"
+            )
+        )
+    )
+)
+
+REM Check required environment variables
+if "%AWS_ACCOUNT_ID%"=="" (
+    echo [ERROR] Missing AWS_ACCOUNT_ID in .env file
+    exit /b 1
+)
+if "%AWS_REGION%"=="" (
+    echo [ERROR] Missing AWS_REGION in .env file
+    exit /b 1
+)
+if "%ECR_REPOSITORY%"=="" (
+    echo [ERROR] Missing ECR_REPOSITORY in .env file
+    exit /b 1
+)
+
+echo [INFO] Starting development environment with ECR base image
+
+REM Run with environment variables
+cd infra\docker
 docker-compose -f docker-compose.yml up

--- a/infra/docker/scripts/dev.sh
+++ b/infra/docker/scripts/dev.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 # Run all containers for development (API + DB)
 
-cd "$(dirname "$0")/.."
+set -e
+
+# Go to project root to load .env
+cd "$(dirname "$0")/../../.."
+
+# Load environment variables from .env file
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | grep -v '^$' | xargs)
+fi
+
+# Check required environment variables
+if [ -z "$AWS_ACCOUNT_ID" ] || [ -z "$AWS_REGION" ] || [ -z "$ECR_REPOSITORY" ]; then
+    echo "[ERROR] Missing required environment variables in .env file:"
+    echo "  AWS_ACCOUNT_ID, AWS_REGION, ECR_REPOSITORY"
+    exit 1
+fi
+
+echo "[INFO] Starting development environment with ECR base image"
+
+# Run with environment variables
+cd infra/docker
 docker compose -f docker-compose.yml up


### PR DESCRIPTION
Summary

  - Migrated all Docker base images from Docker Hub (hero7hero/simple-chatbot) to AWS ECR for private image hosting
  - Implemented AWS OIDC authentication in CI pipeline for secure, keyless AWS access using IAM roles
  - Fixed "invalid reference format" error by properly setting required ECR environment variables in GitHub Actions
  - Updated all build scripts and Docker Compose files to use ECR registry with credentials from .env file
  - Resolved cross-platform Makefile compatibility issues for Windows and Unix systems

  Key Changes

  CI Pipeline (Primary Goal):
  - Added OIDC permissions (id-token: write, contents: read) for secure AWS authentication
  - Replaced manual AWS CLI installation with aws-actions/configure-aws-credentials@v4 and aws-actions/amazon-ecr-login@v2
  - Set required ECR environment variables (AWS_ACCOUNT_ID, AWS_REGION, ECR_REPOSITORY=chatbot, IMAGE_TAG=latest)
  - Changed PR trigger branch from ci_cd to dev
  - Fixed Docker build errors caused by missing environment variables

  Docker Configuration:
  - Updated all Docker Compose files (docker-compose.yml, docker-compose.ci.yml, docker-compose.prod.yml) to use ECR base images
  - Modified Dockerfile to require BASE_IMAGE argument pointing to ECR
  - Removed obsolete version field and unused environment variables from prod compose

  Build Scripts:
  - Enhanced all build scripts (.sh and .bat) to load AWS credentials from .env file
  - Added validation for required environment variables (AWS_ACCOUNT_ID, AWS_REGION, ECR_REPOSITORY)
  - Updated build-base scripts to authenticate with ECR and push images

  Cross-Platform Support:
  - Fixed Makefile to work correctly on both Windows (cmd.exe) and Unix (bash) systems
  - Added proper .gitattributes for line ending normalization (LF for shell scripts, CRLF for batch files)